### PR TITLE
Add support for swift package manager by adding Package.swift and conv…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.3
+
+import PackageDescription
+
+let package = Package(
+    name: "SwiftGS1Barcode",
+    platforms: [
+        .iOS(.v8)
+    ],
+    products: [
+        .library(
+            name: "SwiftGS1Barcode",
+            targets: ["SwiftGS1Barcode"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "SwiftGS1Barcode",
+            dependencies: [],
+            path: "SwiftGS1Barcode",
+            exclude: ["Info.plist"]),
+        .testTarget(
+            name: "SwiftGS1BarcodeTests",
+            dependencies: ["SwiftGS1Barcode"],
+            path: "SwiftGS1BarcodeTests",
+            exclude: ["Info.plist"]),
+    ],
+    swiftLanguageVersions: [.v5]
+)

--- a/SwiftGS1Barcode/Barcode.swift
+++ b/SwiftGS1Barcode/Barcode.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Toni Hoffmann. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 protocol Barcode {
     /* *********** Properties *********** */

--- a/SwiftGS1Barcode/DateExtension.swift
+++ b/SwiftGS1Barcode/DateExtension.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Toni Hoffmann. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 extension Date{
     /** Wrapper function to create a date based on a year, month and day */

--- a/SwiftGS1Barcode/GS1ApplicationIdentifier.swift
+++ b/SwiftGS1Barcode/GS1ApplicationIdentifier.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Toni Hoffmann. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 public enum GS1ApplicationIdentifierType: String{
     case AlphaNumeric

--- a/SwiftGS1Barcode/GS1Barcode.swift
+++ b/SwiftGS1Barcode/GS1Barcode.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Toni Hoffmann. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 public class GS1Barcode: NSObject, Barcode {
     /** RAW Data of the barcode in a string */

--- a/SwiftGS1Barcode/GS1BarcodeErrors.swift
+++ b/SwiftGS1Barcode/GS1BarcodeErrors.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Toni Hoffmann. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 class GS1BarcodeErrors: NSObject {
     /** Error cases for Barcode Parser */

--- a/SwiftGS1Barcode/GS1BarcodeParser.swift
+++ b/SwiftGS1Barcode/GS1BarcodeParser.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Toni Hoffmann. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 public class GS1BarcodeParser: NSObject {
     /** Set to true to prints debug information to console */

--- a/SwiftGS1Barcode/SimpleBarcode.swift
+++ b/SwiftGS1Barcode/SimpleBarcode.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Toni Hoffmann. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 /** Sample class for a Barcode **/
 class SimpleBarcode: NSObject, Barcode {

--- a/SwiftGS1Barcode/StringExtension.swift
+++ b/SwiftGS1Barcode/StringExtension.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Toni Hoffmann. All rights reserved.
 //
 
-import UIKit
+import Foundation
 
 extension String{
     /** Returning a substring of the current element */

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+import SwiftGS1BarcodeTests
+
+var tests = [XCTestCaseEntry]()
+tests += SwiftGS1BarcodeTests.allTests()
+XCTMain(tests)


### PR DESCRIPTION
Add support for swift package manager by adding Package.swift and converting UIKit Imports to Foundation to remove iOS dependency.

### What was the motivation?

Swift Package Manager is the new standard in dependency management in swift projects. It was an easy change, and I'm happy to contribute to the swift community.